### PR TITLE
Add quantity limits.

### DIFF
--- a/helpers/eventProcessor/exchangeConnect/bybit/lib/rest/bybitRestV5.js
+++ b/helpers/eventProcessor/exchangeConnect/bybit/lib/rest/bybitRestV5.js
@@ -64,6 +64,10 @@ class BybitRestV5 {
     return this.request('/account/wallet-balance', 'GET', params)
   }
 
+  getMaxTradeLimits (params) {
+    return this.request('/order/spot-borrow-check', 'GET', params)
+  }
+
   getOrders (params) {
     return this.request('/order/realtime', 'GET', params)
   }

--- a/helpers/eventProcessor/exchangeConnect/exchangeConnect.js
+++ b/helpers/eventProcessor/exchangeConnect/exchangeConnect.js
@@ -133,14 +133,14 @@ class XchgConnect {
       limit: 50
     }
     const ordersResponse = await this.rest.getOrders(params)
-    return ordersResponse.result.list.map((o) => {
+    return ordersResponse.result.list?.map((o) => {
       return { category: 'spot', ...o } // Response missing 'category'.
     })
   }
 
   async updateLimitOrders () {
     const orders = await this.getLimitOrders()
-    if (orders.length > 1) {
+    if (orders?.length > 1) {
       const canceled = await this.rest.cancelAllOrders({
         category: 'spot',
         symbol: this.pair
@@ -152,7 +152,7 @@ class XchgConnect {
         canceled.result.list.map((o) => o.orderId)
       )
     }
-    orders.forEach((o) => this.storeLimitOrder(o, 'closeOrder'))
+    if (orders) orders.forEach((o) => this.storeLimitOrder(o, 'closeOrder'))
   }
 
   storeCandle (candle) {

--- a/helpers/eventProcessor/exchangeConnect/exchangeConnect.js
+++ b/helpers/eventProcessor/exchangeConnect/exchangeConnect.js
@@ -43,6 +43,7 @@ class XchgConnect {
     this.orderbook = { bid: {}, ask: {} }
     this.candles = []
     this.tradingInfo = {}
+    this.maxTradesInfo = { buy: {}, sell: {} }
     this.closeOrder = null
 
     this.lastCandleMsgMts = 0
@@ -242,6 +243,25 @@ class XchgConnect {
     const instrumentInfo = await this.rest.getInstrumentInfo(params)
     this.tradingInfo = instrumentInfo.result.list[0]
     return this.tradingInfo
+  }
+
+  async updateMaxTradesInfo () {
+    const buyInfo = await this.rest.getMaxTradeLimits({
+      category: 'spot',
+      symbol: this.pair,
+      side: 'Buy'
+    })
+
+    const sellInfo = await this.rest.getMaxTradeLimits({
+      category: 'spot',
+      symbol: this.pair,
+      side: 'Sell'
+    })
+
+    if (buyInfo?.retMsg === 'OK') this.maxTradesInfo.buy = buyInfo.result
+    if (sellInfo?.retMsg === 'OK') this.maxTradesInfo.sell = sellInfo.result
+
+    return this.maxTradesInfo
   }
 
   async repayLiability () {

--- a/helpers/eventProcessor/exchangeConnect/exchangeConnect.js
+++ b/helpers/eventProcessor/exchangeConnect/exchangeConnect.js
@@ -63,8 +63,8 @@ class XchgConnect {
   }
 
   setWallet (w) {
-    const { totalMarginBalance: mBce, totalAvailableBalance: aBce } = w
-    this.logger('log', true, `WU: marginBce: ${mBce} availableBce: ${aBce}`)
+    const { totalEquity: mBce, totalAvailableBalance: aBce } = w
+    this.logger('log', true, `WU: totalBce: ${mBce} availableBce: ${aBce}`)
     const coinsToWallet = w.coin.reduce((prev, curr) => {
       const { coin, walletBalance: balance, borrowAmount } = curr
       if (!this.walletCoins.includes(coin)) return prev

--- a/helpers/eventProcessor/strategy.js
+++ b/helpers/eventProcessor/strategy.js
@@ -74,7 +74,8 @@ class Strategy {
     if (askPrice > openBuyPrice) return false
     const baseAmount = Math.min(
       currencyAvailable / askPrice * this.leverage,
-      askAmount * 0.75
+      askAmount * 0.75,
+      +this.maxTradesInfo.buy?.maxTradeQty * 0.95 || 0
     )
     const amountBasePrec = 1 / +this.tradingInfo.lotSizeFilter.basePrecision
     const amount = Math.round(baseAmount * amountBasePrec) / amountBasePrec
@@ -88,7 +89,8 @@ class Strategy {
     if (bidPrice < openSellPrice) return false
     const baseAmount = Math.min(
       currencyAvailable / bidPrice * this.leverage,
-      bidAmount * 0.75
+      bidAmount * 0.75,
+      +this.maxTradesInfo.sell?.maxTradeQty * 0.95 || 0
     )
     const amountBasePrec = 1 / +this.tradingInfo.lotSizeFilter.basePrecision
     const amount = Math.round(baseAmount * amountBasePrec) / amountBasePrec

--- a/helpers/eventProcessor/strategy.js
+++ b/helpers/eventProcessor/strategy.js
@@ -8,6 +8,7 @@ class Strategy {
     this.initStrategyParams(inputParams)
     this.bollinger = new Bollinger(inputParams)
     this.tradingInfo = null // Bybit limitations for trading pair.
+    this.maxTradesInfo = { buy: {}, sell: {} } // From rest endpoint.
   }
 
   initStrategyParams (inputParams) {

--- a/helpers/eventProcessor/strategy.js
+++ b/helpers/eventProcessor/strategy.js
@@ -61,12 +61,11 @@ class Strategy {
   }
 
   calcCurrencyAvailable (wallet) {
-    // Get ratio un usd equivalent and apply it to balance.
-    const { coinsToWallet, totalMarginBalance } = wallet
-    const assetUsdEq = Math.abs(+coinsToWallet[this.asset].usdValue)
-    const maxUsdEqToTrade = +totalMarginBalance * this.leverage
-    const availableRatio = (maxUsdEqToTrade - assetUsdEq) / maxUsdEqToTrade
-    return Math.max(availableRatio * totalMarginBalance, 0)
+    // Get ratio in usd equivalent and apply it to balance.
+    const { coinsToWallet, totalEquity } = wallet
+    const assetInUsd = +coinsToWallet[this.asset].usdValue
+    const assetUsdEq = Math.abs(assetInUsd) / this.leverage
+    return Math.max(+totalEquity - assetUsdEq, 0)
   }
 
   getOpenBuyOrderInfo (currencyAvailable, orderbook) {

--- a/helpers/eventProcessor/strategy.js
+++ b/helpers/eventProcessor/strategy.js
@@ -21,8 +21,10 @@ class Strategy {
     this.leverage = inputParams.leverage
   }
 
-  setTradingInfo (tradingInfo) {
-    this.tradingInfo = tradingInfo
+  setAttributesValue (attributesToValue) {
+    for (const [attribute, value] of Object.entries(attributesToValue)) {
+      this[attribute] = value
+    }
   }
 
   getCloseSellOrderInfo (assetBalance) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-stable-bot",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Stable bot developed for bybit.",
   "main": "index.js",
   "scripts": {

--- a/tests/bybitRestV5.test.js
+++ b/tests/bybitRestV5.test.js
@@ -44,8 +44,8 @@ describe('Test on RestV5Module class.', function () {
     // Data.
     const neededMethods = [
       'constructor', 'request', 'getCandles', 'getInstrumentInfo',
-      'getOrderBook', 'getWalletBalance', 'getOrders', 'cancelAllOrders',
-      'repay'
+      'getOrderBook', 'getWalletBalance', 'getMaxTradeLimits', 'getOrders',
+      'cancelAllOrders', 'repay'
     ]
 
     // Assertions.
@@ -175,6 +175,17 @@ describe('Test on RestV5Module class.', function () {
     assert.strictEqual(output, 'response')
     assert(
       stub.calledOnceWithExactly('/account/wallet-balance', 'GET', 'params')
+    )
+    stub.restore()
+  })
+
+  it('Method getMaxTradeLimits should GET wallet endpoint.', function () {
+    const stub = sinon.stub(restV5, 'request')
+    stub.returns('response')
+    const output = restV5.getMaxTradeLimits('params')
+    assert.strictEqual(output, 'response')
+    assert(
+      stub.calledOnceWithExactly('/order/spot-borrow-check', 'GET', 'params')
     )
     stub.restore()
   })

--- a/tests/strategy.test.js
+++ b/tests/strategy.test.js
@@ -304,32 +304,51 @@ describe('Test on Strategy class.', function () {
       {
         currencyAvailable: 10.1,
         orderbook: { ask: { askPrice: 1.01, askAmount: 10000 } },
+        maxTradesInfo: { buy: { maxTradeQty: 120 } },
         openBuyPrice: 1,
         expected: false
       },
       {
         currencyAvailable: 0.099,
         orderbook: { ask: { askPrice: 1, askAmount: 1000 } },
+        maxTradesInfo: { buy: { maxTradeQty: 120 } },
         openBuyPrice: 1,
         expected: false
       },
       {
         currencyAvailable: 10.1,
         orderbook: { ask: { askPrice: 1, askAmount: 1 } },
+        maxTradesInfo: { buy: { maxTradeQty: 120 } },
         openBuyPrice: 1,
         expected: false
       },
       {
         currencyAvailable: 10.1,
         orderbook: { ask: { askPrice: 1, askAmount: 4.44444 } },
+        maxTradesInfo: { buy: { maxTradeQty: 120 } },
         openBuyPrice: 1,
         expected: { type: 'openBuyOrder', side: 'Buy', amount: 3.33 }
       },
       {
+        currencyAvailable: 10.1,
+        orderbook: { ask: { askPrice: 1, askAmount: 1000 } },
+        maxTradesInfo: { buy: { maxTradeQty: 5 } },
+        openBuyPrice: 1,
+        expected: { type: 'openBuyOrder', side: 'Buy', amount: 4.75 }
+      },
+      {
         currencyAvailable: 1.01,
         orderbook: { ask: { askPrice: 1, askAmount: 100000 } },
+        maxTradesInfo: { buy: { maxTradeQty: 120 } },
         openBuyPrice: 1.01,
         expected: { type: 'openBuyOrder', side: 'Buy', amount: 10.1 }
+      },
+      {
+        currencyAvailable: 1.01,
+        orderbook: { ask: { askPrice: 1, askAmount: 100000 } },
+        maxTradesInfo: { buy: {} },
+        openBuyPrice: 1.01,
+        expected: false
       }
     ]
 
@@ -337,6 +356,7 @@ describe('Test on Strategy class.', function () {
     for (const test of tests) {
       const stub = sinon.stub(strategy.bollinger, 'getBollingerPrices')
       stub.returns({ openBuyPrice: test.openBuyPrice })
+      strategy.maxTradesInfo = test.maxTradesInfo
       const output = strategy.getOpenBuyOrderInfo(
         test.currencyAvailable,
         test.orderbook
@@ -344,6 +364,7 @@ describe('Test on Strategy class.', function () {
       assert.deepStrictEqual(output, test.expected)
 
       // Restores.
+      strategy.maxTradesInfo = { buy: {}, sell: {} }
       stub.restore()
     }
     strategy.leverage = mockParams.leverage
@@ -360,32 +381,51 @@ describe('Test on Strategy class.', function () {
       {
         currencyAvailable: 10.1,
         orderbook: { bid: { bidPrice: 0.99, bidAmount: 10000 } },
+        maxTradesInfo: { sell: { maxTradeQty: 120 } },
         openSellPrice: 1,
         expected: false
       },
       {
         currencyAvailable: 0.099,
         orderbook: { bid: { bidPrice: 1, bidAmount: 1000 } },
+        maxTradesInfo: { sell: { maxTradeQty: 120 } },
         openSellPrice: 1,
         expected: false
       },
       {
         currencyAvailable: 10.1,
         orderbook: { bid: { bidPrice: 1, bidAmount: 1 } },
+        maxTradesInfo: { sell: { maxTradeQty: 120 } },
         openSellPrice: 1,
         expected: false
       },
       {
         currencyAvailable: 10.1,
         orderbook: { bid: { bidPrice: 1, bidAmount: 4.44444 } },
+        maxTradesInfo: { sell: { maxTradeQty: 120 } },
         openSellPrice: 1,
         expected: { type: 'openSellOrder', side: 'Sell', amount: 3.33 }
       },
       {
+        currencyAvailable: 10.1,
+        orderbook: { bid: { bidPrice: 1, bidAmount: 1000 } },
+        maxTradesInfo: { sell: { maxTradeQty: 5 } },
+        openSellPrice: 1,
+        expected: { type: 'openSellOrder', side: 'Sell', amount: 4.75 }
+      },
+      {
         currencyAvailable: 1.01,
         orderbook: { bid: { bidPrice: 1, bidAmount: 100000 } },
+        maxTradesInfo: { sell: { maxTradeQty: 120 } },
         openSellPrice: 0.99,
         expected: { type: 'openSellOrder', side: 'Sell', amount: 10.1 }
+      },
+      {
+        currencyAvailable: 1.01,
+        orderbook: { bid: { bidPrice: 1, bidAmount: 100000 } },
+        maxTradesInfo: { sell: {} },
+        openSellPrice: 0.99,
+        expected: false
       }
     ]
 
@@ -393,6 +433,7 @@ describe('Test on Strategy class.', function () {
     for (const test of tests) {
       const stub = sinon.stub(strategy.bollinger, 'getBollingerPrices')
       stub.returns({ openSellPrice: test.openSellPrice })
+      strategy.maxTradesInfo = test.maxTradesInfo
       const output = strategy.getOpenSellOrderInfo(
         test.currencyAvailable,
         test.orderbook
@@ -400,6 +441,7 @@ describe('Test on Strategy class.', function () {
       assert.deepStrictEqual(output, test.expected)
 
       // Restores.
+      strategy.maxTradesInfo = { buy: {}, sell: {} }
       stub.restore()
     }
     strategy.leverage = mockParams.leverage

--- a/tests/strategy.test.js
+++ b/tests/strategy.test.js
@@ -267,29 +267,15 @@ describe('Test on Strategy class.', function () {
       const tests = [
         {
           wallet: {
-            coinsToWallet: { USDC: { usdValue: '-10' } },
-            totalMarginBalance: '10'
+            coinsToWallet: { USDC: { usdValue: '-100' } },
+            totalEquity: '19'
           },
           expected: 9
         },
         {
           wallet: {
-            coinsToWallet: { USDC: { usdValue: '0' } },
-            totalMarginBalance: '10'
-          },
-          expected: 10
-        },
-        {
-          wallet: {
-            coinsToWallet: { USDC: { usdValue: '100' } },
-            totalMarginBalance: '10'
-          },
-          expected: 0
-        },
-        {
-          wallet: {
-            coinsToWallet: { USDC: { usdValue: '-101' } },
-            totalMarginBalance: '10'
+            coinsToWallet: { USDC: { usdValue: '-1010' } },
+            totalEquity: '100'
           },
           expected: 0
         }

--- a/tests/strategy.test.js
+++ b/tests/strategy.test.js
@@ -61,7 +61,7 @@ describe('Test on Strategy class.', function () {
   it('Should have all needed methods.', function () {
     // Data.
     const neededMethods = [
-      'constructor', 'initStrategyParams', 'setTradingInfo',
+      'constructor', 'initStrategyParams', 'setAttributesValue',
       'getCloseSellOrderInfo', 'getCloseBuyOrderInfo', 'getCloseOrderInfo',
       'calcCurrencyAvailable', 'getOpenBuyOrderInfo', 'getOpenSellOrderInfo',
       'getOpenOrderInfo', 'getOrderNeededInfo'
@@ -79,9 +79,9 @@ describe('Test on Strategy class.', function () {
     }
   })
 
-  it('Method setTradingInfo should set value.', function () {
+  it('Method setAttributesValue should set attribute value.', function () {
     strategy.tradingInfo = null
-    const mockTradingInfo = {
+    const tradingInfo = {
       symbol: 'USDCUSDT',
       baseCoin: 'USDC',
       quoteCoin: 'USDT',
@@ -99,8 +99,8 @@ describe('Test on Strategy class.', function () {
       priceFilter: { tickSize: '0.0001' },
       riskParameters: { limitParameter: '0.01', marketParameter: '0.01' }
     }
-    strategy.setTradingInfo(mockTradingInfo)
-    assert.deepStrictEqual(strategy.tradingInfo, mockTradingInfo)
+    strategy.setAttributesValue({ tradingInfo })
+    assert.deepStrictEqual(strategy.tradingInfo, tradingInfo)
     strategy.tradingInfo = null
   })
 

--- a/tests/strategy.test.js
+++ b/tests/strategy.test.js
@@ -55,6 +55,7 @@ describe('Test on Strategy class.', function () {
     assert.strictEqual(strategy.maxBuyPrice, 1.0002)
     assert.strictEqual(strategy.leverage, 10)
     assert.strictEqual(strategy.tradingInfo, null)
+    assert.deepStrictEqual(strategy.maxTradesInfo, { buy: {}, sell: {} })
     assert(strategy.bollinger instanceof MockBollinger)
   })
 


### PR DESCRIPTION
This PR add verification of maximum amount for open offers through a rest endpoint.

Bybit limits amount to offer in different market conditions. Even though account/pair has x10 leverage available it may limit shorts or longs even to x5.
Channel though ws not available. Rest endpoint stable enough.   